### PR TITLE
Add init to subnamespace

### DIFF
--- a/cranial/common/__init__.py
+++ b/cranial/common/__init__.py
@@ -1,0 +1,1 @@
+from .common import *

--- a/cranial/common/__init__.py
+++ b/cranial/common/__init__.py
@@ -1,1 +1,1 @@
-from .common import *
+from cranial.common import *


### PR DESCRIPTION
Fixing
```
Error processing line 1 of /usr/local/Cellar/python/3.7.0/Frameworks/Python.framework/Versions/3.7/lib/python3.7/site-packages/cranial_common-0.2.0-py3.7-nspkg.pth:

  Traceback (most recent call last):
    File "/usr/local/Cellar/python/3.7.0/Frameworks/Python.framework/Versions/3.7/lib/python3.7/site.py", line 168, in addpackage
      exec(line)
    File "<string>", line 1, in <module>
    File "<frozen importlib._bootstrap>", line 580, in module_from_spec
  AttributeError: 'NoneType' object has no attribute 'loader'
```